### PR TITLE
Quick fix regarding the `box` function

### DIFF
--- a/src/tree.jl
+++ b/src/tree.jl
@@ -290,7 +290,7 @@ qbox(depth) = qbox(typeof(eps()), depth)
 
 
 function box!(box, node::SpatialTree)
-  box .= qbox(eltype(box), node) ./ scalar(node) .+ translation(node)
+  box .= qbox(eltype(box), node) ./ scalar(node)
   return box
 end
 box(T, node::SpatialTree) = box!(Vector{T}(undef, bitlen(node)), node)


### PR DESCRIPTION
# Description

This PR is a quick fix regarding the `box` function. The `box` is an extension of the `qbox` function which computes the limits of a quantized box in a given level of the tree. The `box` function does the same thing but for boxes of the original space. Since the box limits are relative to the box center, the computation of the `box` function only relies on the scaling parameter of the space and not the translational vector.

## Type of change

- [ ] Documentation
- [ ] Refactoring
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change


# How Has This Been Tested?

All tests pass and the `/examples/pbmc.jl` knn search returns correct results compared to the brute force kNN of the NearestNeighbors.jl package.